### PR TITLE
fix(ios): queue concurrent permission requests

### DIFF
--- a/ClaudeRemote/Sources/ClaudeRemote/Models/AppState.swift
+++ b/ClaudeRemote/Sources/ClaudeRemote/Models/AppState.swift
@@ -115,8 +115,6 @@ public final class AppState {
     // MARK: - Pending State
     /// Recent user messages for deduplication (normalized content -> timestamp)
     public var recentUserMessages: [String: Date] = [:]
-    /// Queued prompt message during session switching
-    public var pendingPromptMessage: ServerMessage?
 
     // MARK: - Subagent Correlation
     /// Pending subagent_starting messages awaiting agentId correlation (FIFO).

--- a/ClaudeRemote/Sources/ClaudeRemote/Services/AppCoordinator.swift
+++ b/ClaudeRemote/Sources/ClaudeRemote/Services/AppCoordinator.swift
@@ -74,6 +74,7 @@ public final class AppCoordinator: WebSocketServiceDelegate {
         }
         webSocket?.setLastWatchedSession(sessionId)
         webSocket?.send(.watchSession(sessionId: sessionId))
+        promptService.clearQueue()
         promptService.sessionId = sessionId
     }
 
@@ -346,8 +347,13 @@ public final class AppCoordinator: WebSocketServiceDelegate {
                 state.updateSubagentMessage(at: msgIndex, status: "running", tool: nil, agentId: agentId)
             }
 
-        case .subagentOutput:
-            break  // Suppressed — activity shown in inline card + badge detail sheet
+        case .subagentOutput(let agentId, _, let data):
+            // Route subagent permission_request and ask_user_question to the prompt queue
+            if let data, (data.type == "permission_request" || data.type == "ask_user_question") {
+                let desc = state.activeSubagents[agentId]?.description
+                promptService.handleClaudeOutput(data, agentDescription: desc)
+            }
+            // Other subagent output suppressed — activity shown in inline card + badge detail sheet
 
         case .subagentTool(let agentId, let tool, _):
             state.activeSubagents[agentId]?.currentTool = tool

--- a/ClaudeRemote/Sources/ClaudeRemote/Services/PromptService.swift
+++ b/ClaudeRemote/Sources/ClaudeRemote/Services/PromptService.swift
@@ -20,40 +20,60 @@ public struct PromptItem: Identifiable, Sendable, Equatable {
     public let kind: PromptKind
     public let arrivedAt: Date
     public var isStale: Bool
+    /// Correlation ID for matching tool_result dismissals to the correct queue item
+    public let toolUseId: String?
+    /// Human-readable label for subagent permissions (e.g. "Security review of iOS app")
+    public let agentDescription: String?
+    /// Monotonic arrival order for FIFO sorting (0 = unordered, appended at end)
+    let arrivalOrder: Int
 
     public init(
         kind: PromptKind,
         arrivedAt: Date = Date(),
-        isStale: Bool = false
+        isStale: Bool = false,
+        toolUseId: String? = nil,
+        agentDescription: String? = nil,
+        arrivalOrder: Int = 0
     ) {
         self.id = UUID()
         self.kind = kind
         self.arrivedAt = arrivedAt
         self.isStale = isStale
+        self.toolUseId = toolUseId
+        self.agentDescription = agentDescription
+        self.arrivalOrder = arrivalOrder
     }
 }
 
 /// Manages prompt queue, delay-suppress, staleness, auto-dismiss, and history recovery.
 ///
-/// Ported from the web client's `prompts.js` patterns.
+/// Supports multiple concurrent permissions via a FIFO queue. The queue head
+/// (`currentPrompt`) is the actionable item; subsequent items are visible but
+/// have disabled buttons until they become the head.
 @Observable
 @MainActor
 public final class PromptService {
     // MARK: - Public State
 
-    /// The active prompt being displayed (nil when no prompt)
-    public private(set) var currentPrompt: PromptItem?
+    /// All pending prompts in FIFO order. The head (first) is the active prompt.
+    public private(set) var promptQueue: [PromptItem] = []
+
+    /// The active prompt being displayed — queue head (nil when queue is empty).
+    public var currentPrompt: PromptItem? { promptQueue.first }
 
     // MARK: - Internal State
 
-    /// Number of messages received since the current prompt was shown
+    /// Number of messages received since any prompt was shown
     private var messagesSincePrompt = 0
 
-    /// Pending permission waiting for the 500ms delay to elapse
-    private var pendingPermission: PromptItem?
+    /// Monotonic counter for preserving FIFO order among pending permissions
+    private var arrivalCounter: Int = 0
 
-    /// Timer task for the 500ms permission delay
-    private var delayTask: Task<Void, Never>?
+    /// Permissions waiting for their individual 500ms delays to elapse (keyed by pendingKey)
+    private var pendingPermissions: [String: (item: PromptItem, order: Int)] = [:]
+
+    /// Independent 500ms delay tasks per pending permission (keyed by pendingKey)
+    private var delayTasks: [String: Task<Void, Never>] = [:]
 
     /// Task for multi-select sequential injection
     private var multiSelectTask: Task<Void, Never>?
@@ -76,20 +96,19 @@ public final class PromptService {
     // MARK: - Public API
 
     /// Handle a claude_output message from the server
-    public func handleClaudeOutput(_ data: ClaudeOutputData) {
+    public func handleClaudeOutput(_ data: ClaudeOutputData, agentDescription: String? = nil) {
         switch data.type {
         case "permission_request":
-            handlePermissionRequest(data)
+            handlePermissionRequest(data, agentDescription: agentDescription)
 
         case "ask_user_question":
-            handleQuestion(data)
+            handleQuestion(data, agentDescription: agentDescription)
 
         case "tool_result":
-            // Cancel pending permission if tool_result arrives within 500ms
-            cancelPendingPermission()
-            // Auto-dismiss current permission prompt
-            if case .permission = currentPrompt?.kind {
-                dismissPrompt()
+            // Cancel pending permission matching this tool_result's toolUseId,
+            // or dismiss from queue if already enqueued (but not both)
+            if !cancelPendingPermission(toolUseId: data.toolUseId) {
+                dismissPermission(toolUseId: data.toolUseId)
             }
             incrementMessageCounter()
 
@@ -104,70 +123,90 @@ public final class PromptService {
     /// Handle a session_status change
     public func handleSessionStatus(_ status: SessionStatus) {
         if status == .processing {
-            // Claude moved on — dismiss any active prompt
-            dismissPrompt()
-            cancelPendingPermission()
+            // Claude moved on — dismiss all prompts and pending permissions
+            clearQueue()
         }
     }
 
-    /// Recover a prompt from history (called after loading history messages)
+    /// Recover prompts from history (called after loading history messages).
+    /// Finds ALL unmatched permission_request/ask_user_question entries.
     public func recoverFromHistory(_ messages: [Message], sessionStatus: SessionStatus) {
         guard sessionStatus == .waiting else { return }
 
-        // Scan backwards for the last permission_request or ask_user_question
-        // that doesn't have a subsequent tool_result or user message
-        var foundPromptIndex: Int?
+        // Collect all prompt messages and track which have been answered
+        var answeredToolUseIds: Set<String> = []
+        var unansweredPrompts: [Message] = []
+
+        // Scan forward to find tool_results and user messages
+        for msg in messages {
+            if msg.type == .toolResult, let tuId = msg.toolUseId {
+                answeredToolUseIds.insert(tuId)
+            }
+        }
+
+        // Scan backwards to find unanswered prompts
+        // Stop at the first user message (everything before it was answered)
         for i in stride(from: messages.count - 1, through: 0, by: -1) {
             let msg = messages[i]
-            if msg.type == .toolResult || msg.type == .user {
-                // A response was already given — no recovery needed
+            if msg.type == .user {
                 break
             }
             if msg.type == .permissionRequest || msg.type == .askUserQuestion {
-                foundPromptIndex = i
-                break
+                if let tuId = msg.toolUseId, answeredToolUseIds.contains(tuId) {
+                    continue // Already answered
+                }
+                unansweredPrompts.insert(msg, at: 0) // Maintain order
             }
         }
 
-        guard let index = foundPromptIndex else { return }
-        let msg = messages[index]
-
-        if msg.type == .permissionRequest {
-            let prompt = PromptItem(
-                kind: .permission(
-                    tool: msg.tool,
-                    command: extractCommand(from: msg),
-                    isDestructive: msg.isDestructive
-                ),
-                arrivedAt: msg.timestamp,
-                isStale: true
-            )
-            showPrompt(prompt)
-        } else if msg.type == .askUserQuestion, let questions = msg.questions, !questions.isEmpty {
-            let prompt = PromptItem(
-                kind: .question(questions: questions),
-                arrivedAt: msg.timestamp,
-                isStale: true
-            )
-            showPrompt(prompt)
+        for msg in unansweredPrompts {
+            if msg.type == .permissionRequest {
+                let prompt = PromptItem(
+                    kind: .permission(
+                        tool: msg.tool,
+                        command: extractCommand(from: msg),
+                        isDestructive: msg.isDestructive
+                    ),
+                    arrivedAt: msg.timestamp,
+                    isStale: true,
+                    toolUseId: msg.toolUseId
+                )
+                enqueuePrompt(prompt)
+            } else if msg.type == .askUserQuestion, let questions = msg.questions, !questions.isEmpty {
+                let prompt = PromptItem(
+                    kind: .question(questions: questions),
+                    arrivedAt: msg.timestamp,
+                    isStale: true
+                )
+                enqueuePrompt(prompt)
+            }
         }
     }
 
-    /// Dismiss the current prompt
+    /// Dismiss the current (head) prompt
     public func dismiss() {
-        dismissPrompt()
+        dismissHead()
+        // Cancel multi-select even if queue was already empty
+        // (respondMultiSelect dismisses head before starting its task)
+        multiSelectTask?.cancel()
+        multiSelectTask = nil
     }
 
     /// Respond with a single text value (for "Other" freeform input or single-select)
     public func respond(text: String) {
         guard let sid = sessionId else { return }
         sendHandler?(.inject(command: text, sessionId: sid))
-        dismissPrompt()
+        dismissHead()
     }
 
-    /// Respond to a permission prompt
+    /// Respond to a permission prompt (always applies to queue head)
     public func respondPermission(_ choice: PermissionChoice) {
         guard let sid = sessionId else { return }
+        let respondedTool = currentPrompt.flatMap { prompt -> String? in
+            if case .permission(let tool, _, _) = prompt.kind { return tool }
+            return nil
+        }
+
         switch choice {
         case .allow:
             sendHandler?(.inject(command: "y", sessionId: sid))
@@ -176,14 +215,19 @@ public final class PromptService {
         case .deny:
             sendHandler?(.inject(command: "n", sessionId: sid))
         }
-        dismissPrompt()
+        dismissHead()
+
+        // "Allow Always" cascade: remove other permissions with the same tool
+        if choice == .allowAlways, let tool = respondedTool {
+            cascadeAlwaysAllow(tool: tool)
+        }
     }
 
     /// Respond with multiple selections (multi-select question)
     /// Injects each selection with 1000ms delay, then submits with empty string
     public func respondMultiSelect(_ selections: [String]) {
         guard let sid = sessionId else { return }
-        dismissPrompt()
+        dismissHead()
 
         multiSelectTask = Task { @MainActor [sendHandler] in
             for selection in selections {
@@ -197,65 +241,146 @@ public final class PromptService {
         }
     }
 
+    /// Clear the entire queue (used on session switch)
+    public func clearQueue() {
+        promptQueue.removeAll()
+        messagesSincePrompt = 0
+        cancelAllPendingPermissions()
+        multiSelectTask?.cancel()
+        multiSelectTask = nil
+    }
+
     // MARK: - Private
 
-    private func handlePermissionRequest(_ data: ClaudeOutputData) {
-        // Cancel any existing pending permission
-        cancelPendingPermission()
-
+    private func handlePermissionRequest(_ data: ClaudeOutputData, agentDescription: String?) {
         let command = data.content ?? data.input?["command"]?.stringValue
+        let pendingKey = data.toolUseId ?? UUID().uuidString
+        arrivalCounter += 1
+        let order = arrivalCounter
         let prompt = PromptItem(
             kind: .permission(
                 tool: data.tool,
                 command: command,
                 isDestructive: data.isDestructive ?? false
-            )
+            ),
+            toolUseId: data.toolUseId,
+            agentDescription: agentDescription,
+            arrivalOrder: order
         )
 
-        // Store as pending and start 500ms timer
-        pendingPermission = prompt
-        delayTask = Task { @MainActor [weak self] in
+        // Store as pending with arrival order and start independent 500ms timer
+        pendingPermissions[pendingKey] = (item: prompt, order: order)
+        delayTasks[pendingKey] = Task { @MainActor [weak self] in
             try? await Task.sleep(for: .milliseconds(500))
             guard !Task.isCancelled, let self else { return }
-            // Timer fired — show the permission card
-            if let pending = self.pendingPermission {
-                self.pendingPermission = nil
-                self.showPrompt(pending)
+            if let pending = self.pendingPermissions.removeValue(forKey: pendingKey) {
+                self.delayTasks.removeValue(forKey: pendingKey)
+                self.enqueuePrompt(pending.item)
             }
         }
     }
 
-    private func handleQuestion(_ data: ClaudeOutputData) {
+    private func handleQuestion(_ data: ClaudeOutputData, agentDescription: String?) {
         guard let questions = data.questions, !questions.isEmpty else { return }
         // Questions show immediately (no delay)
-        let prompt = PromptItem(kind: .question(questions: questions))
-        showPrompt(prompt)
+        let prompt = PromptItem(
+            kind: .question(questions: questions),
+            agentDescription: agentDescription
+        )
+        enqueuePrompt(prompt)
     }
 
-    private func cancelPendingPermission() {
-        delayTask?.cancel()
-        delayTask = nil
-        pendingPermission = nil
+    /// Cancel a pending permission (still in its 500ms delay). Returns true if found.
+    @discardableResult
+    private func cancelPendingPermission(toolUseId: String?) -> Bool {
+        if let toolUseId {
+            // Cancel the specific pending permission matching this toolUseId
+            for (key, pending) in pendingPermissions where pending.item.toolUseId == toolUseId {
+                delayTasks[key]?.cancel()
+                delayTasks.removeValue(forKey: key)
+                pendingPermissions.removeValue(forKey: key)
+                return true
+            }
+        }
+        // Fallback: cancel the oldest pending permission (by arrival order)
+        if let oldest = pendingPermissions.min(by: { $0.value.order < $1.value.order })?.key {
+            delayTasks[oldest]?.cancel()
+            delayTasks.removeValue(forKey: oldest)
+            pendingPermissions.removeValue(forKey: oldest)
+            return true
+        }
+        return false
     }
 
-    private func showPrompt(_ prompt: PromptItem) {
-        currentPrompt = prompt
+    private func cancelAllPendingPermissions() {
+        for (_, task) in delayTasks { task.cancel() }
+        delayTasks.removeAll()
+        pendingPermissions.removeAll()
+    }
+
+    /// Enqueue a prompt. Items with arrivalOrder > 0 are inserted in FIFO order
+    /// to handle 500ms delay tasks that may fire out of scheduling order.
+    /// Items with arrivalOrder == 0 (questions, history recovery) are appended at the end.
+    private func enqueuePrompt(_ prompt: PromptItem) {
+        if prompt.arrivalOrder > 0 {
+            // Sorted insertion: find first item with a higher arrivalOrder
+            let insertAt = promptQueue.firstIndex(where: { $0.arrivalOrder > prompt.arrivalOrder })
+                ?? promptQueue.count
+            promptQueue.insert(prompt, at: insertAt)
+        } else {
+            promptQueue.append(prompt)
+        }
+        if promptQueue.count == 1 {
+            messagesSincePrompt = 0
+        }
+    }
+
+    private func dismissHead() {
+        guard !promptQueue.isEmpty else { return }
+        promptQueue.removeFirst()
         messagesSincePrompt = 0
-    }
-
-    private func dismissPrompt() {
-        currentPrompt = nil
-        messagesSincePrompt = 0
-        cancelPendingPermission()
         multiSelectTask?.cancel()
         multiSelectTask = nil
     }
 
+    /// Dismiss a specific queued permission matching a tool_result's toolUseId
+    private func dismissPermission(toolUseId: String?) {
+        if let toolUseId {
+            if let idx = promptQueue.firstIndex(where: { $0.toolUseId == toolUseId }) {
+                promptQueue.remove(at: idx)
+                return
+            }
+        }
+        // Fallback: dismiss the head if it's a permission
+        if case .permission = promptQueue.first?.kind {
+            dismissHead()
+        }
+    }
+
+    /// After "Allow Always", proactively remove other permissions for the same tool
+    private func cascadeAlwaysAllow(tool: String) {
+        // Cancel pending permissions for the same tool
+        for (key, pending) in pendingPermissions {
+            if case .permission(let t, _, _) = pending.item.kind, t == tool {
+                delayTasks[key]?.cancel()
+                delayTasks.removeValue(forKey: key)
+                pendingPermissions.removeValue(forKey: key)
+            }
+        }
+        // Remove queued permissions for the same tool
+        promptQueue.removeAll { item in
+            if case .permission(let t, _, _) = item.kind { return t == tool }
+            return false
+        }
+    }
+
     private func incrementMessageCounter() {
-        guard currentPrompt != nil else { return }
+        guard !promptQueue.isEmpty else { return }
         messagesSincePrompt += 1
-        if messagesSincePrompt >= 2, currentPrompt?.isStale == false {
-            currentPrompt?.isStale = true
+        if messagesSincePrompt >= 2 {
+            for i in promptQueue.indices where !promptQueue[i].isStale {
+                promptQueue[i].isStale = true
+            }
         }
     }
 

--- a/ClaudeRemote/Sources/ClaudeRemote/Views/Components/PromptCardView.swift
+++ b/ClaudeRemote/Sources/ClaudeRemote/Views/Components/PromptCardView.swift
@@ -1,40 +1,73 @@
 import SwiftUI
 
-/// Renders the current prompt card (permission or question)
+/// Renders the prompt queue as a stacked card list.
+/// Queue head is actionable; non-head items show as pending with disabled buttons.
 struct PromptCardView: View {
     @Environment(AppCoordinator.self) private var coordinator
 
+    /// Maximum number of fully-rendered cards before showing "+N more"
+    private static let maxVisible = 3
+
+    private var queue: [PromptItem] { coordinator.promptService.promptQueue }
+
     var body: some View {
-        if let prompt = coordinator.promptService.currentPrompt {
+        if !queue.isEmpty {
             VStack(spacing: 0) {
                 Divider()
-                cardContent(for: prompt)
-                    .padding(12)
-                    .background(.regularMaterial)
+                VStack(spacing: 8) {
+                    ForEach(Array(queue.prefix(Self.maxVisible).enumerated()), id: \.element.id) { index, prompt in
+                        cardContent(for: prompt, isHead: index == 0)
+                    }
+                    if queue.count > Self.maxVisible {
+                        overflowIndicator(remaining: queue.count - Self.maxVisible)
+                    }
+                }
+                .padding(12)
+                .background(.regularMaterial)
             }
         }
     }
 
     @ViewBuilder
-    private func cardContent(for prompt: PromptItem) -> some View {
-        switch prompt.kind {
-        case .permission(let tool, let command, let isDestructive):
-            PermissionCardContent(
-                tool: tool,
-                command: command,
-                isDestructive: isDestructive,
-                isStale: prompt.isStale,
-                onRespond: { coordinator.promptService.respondPermission($0) }
-            )
+    private func cardContent(for prompt: PromptItem, isHead: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let desc = prompt.agentDescription {
+                Text(desc)
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+                    .padding(.bottom, 4)
+            }
 
-        case .question(let questions):
-            QuestionCardContent(
-                questions: questions,
-                isStale: prompt.isStale,
-                onRespond: { coordinator.promptService.respond(text: $0) },
-                onRespondMulti: { coordinator.promptService.respondMultiSelect($0) }
-            )
+            switch prompt.kind {
+            case .permission(let tool, let command, let isDestructive):
+                PermissionCardContent(
+                    tool: tool,
+                    command: command,
+                    isDestructive: isDestructive,
+                    isStale: prompt.isStale,
+                    isHead: isHead,
+                    onRespond: { coordinator.promptService.respondPermission($0) }
+                )
+
+            case .question(let questions):
+                QuestionCardContent(
+                    questions: questions,
+                    isStale: prompt.isStale,
+                    isHead: isHead,
+                    onRespond: { coordinator.promptService.respond(text: $0) },
+                    onRespondMulti: { coordinator.promptService.respondMultiSelect($0) }
+                )
+            }
         }
+        .opacity(isHead ? 1.0 : 0.6)
+    }
+
+    private func overflowIndicator(remaining: Int) -> some View {
+        Text("+\(remaining) more pending")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 4)
     }
 }
 
@@ -53,6 +86,19 @@ private struct StaleBadge: View {
     }
 }
 
+private struct PendingBadge: View {
+    var body: some View {
+        Text("Pending")
+            .font(.caption2)
+            .fontWeight(.medium)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(.secondary.opacity(0.2))
+            .foregroundStyle(.secondary)
+            .clipShape(Capsule())
+    }
+}
+
 // MARK: - Permission Card
 
 private struct PermissionCardContent: View {
@@ -60,6 +106,7 @@ private struct PermissionCardContent: View {
     let command: String?
     let isDestructive: Bool
     let isStale: Bool
+    let isHead: Bool
     let onRespond: (PermissionChoice) -> Void
 
     var body: some View {
@@ -68,7 +115,9 @@ private struct PermissionCardContent: View {
                 Text("Allow \(tool ?? "Tool")?")
                     .font(.headline)
                 Spacer()
-                if isStale {
+                if !isHead {
+                    PendingBadge()
+                } else if isStale {
                     StaleBadge()
                 }
             }
@@ -76,38 +125,40 @@ private struct PermissionCardContent: View {
             if let command, !command.isEmpty {
                 Text(command)
                     .font(.system(.caption, design: .monospaced))
-                    .lineLimit(3)
+                    .lineLimit(isHead ? 3 : 1)
                     .padding(8)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(.gray.opacity(0.08))
                     .clipShape(RoundedRectangle(cornerRadius: 6))
             }
 
-            HStack(spacing: 10) {
-                Button {
-                    onRespond(.deny)
-                } label: {
-                    Text("Deny")
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.bordered)
-                .tint(isDestructive ? .red : nil)
+            if isHead {
+                HStack(spacing: 10) {
+                    Button {
+                        onRespond(.deny)
+                    } label: {
+                        Text("Deny")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(isDestructive ? .red : nil)
 
-                Button {
-                    onRespond(.allow)
-                } label: {
-                    Text("Allow")
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.borderedProminent)
+                    Button {
+                        onRespond(.allow)
+                    } label: {
+                        Text("Allow")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
 
-                Button {
-                    onRespond(.allowAlways)
-                } label: {
-                    Text("Always")
-                        .frame(maxWidth: .infinity)
+                    Button {
+                        onRespond(.allowAlways)
+                    } label: {
+                        Text("Always")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
                 }
-                .buttonStyle(.bordered)
             }
         }
     }
@@ -118,6 +169,7 @@ private struct PermissionCardContent: View {
 private struct QuestionCardContent: View {
     let questions: [QuestionData]
     let isStale: Bool
+    let isHead: Bool
     let onRespond: (String) -> Void
     let onRespondMulti: ([String]) -> Void
 
@@ -126,6 +178,7 @@ private struct QuestionCardContent: View {
             SingleQuestionView(
                 question: question,
                 isStale: isStale,
+                isHead: isHead,
                 onSubmit: onRespond,
                 onSubmitMulti: onRespondMulti
             )
@@ -136,6 +189,7 @@ private struct QuestionCardContent: View {
 private struct SingleQuestionView: View {
     let question: QuestionData
     let isStale: Bool
+    let isHead: Bool
     let onSubmit: (String) -> Void
     let onSubmitMulti: ([String]) -> Void
 
@@ -157,7 +211,9 @@ private struct SingleQuestionView: View {
                         .font(.headline)
                 }
                 Spacer()
-                if isStale {
+                if !isHead {
+                    PendingBadge()
+                } else if isStale {
                     StaleBadge()
                 }
             }
@@ -273,7 +329,7 @@ private struct SingleQuestionView: View {
                 .frame(maxWidth: .infinity)
         }
         .buttonStyle(.borderedProminent)
-        .disabled(!canSubmit)
+        .disabled(!canSubmit || !isHead)
     }
 
     private var canSubmit: Bool {

--- a/ClaudeRemote/Sources/ClaudeRemote/Views/ContentView.swift
+++ b/ClaudeRemote/Sources/ClaudeRemote/Views/ContentView.swift
@@ -130,13 +130,13 @@ struct MainView: View {
                     activityBar(activity)
                         .transition(.opacity)
                 }
-                if coordinator.promptService.currentPrompt != nil {
+                if !coordinator.promptService.promptQueue.isEmpty {
                     PromptCardView()
                         .transition(.move(edge: .bottom).combined(with: .opacity))
                 }
                 InputBarView()
             }
-            .animation(.easeInOut(duration: 0.25), value: coordinator.promptService.currentPrompt != nil)
+            .animation(.easeInOut(duration: 0.25), value: coordinator.promptService.promptQueue.count)
             .animation(.easeInOut(duration: 0.2), value: state.currentActivity != nil)
         }
         .navigationTitle(currentSessionName)

--- a/ClaudeRemote/Tests/ClaudeRemoteTests/Services/AppCoordinatorTests.swift
+++ b/ClaudeRemote/Tests/ClaudeRemoteTests/Services/AppCoordinatorTests.swift
@@ -520,6 +520,57 @@ struct AppCoordinatorTests {
     }
 
     @MainActor
+    @Test("subagentOutput routes permission_request to prompt queue")
+    func subagentOutputRoutesPermission() async throws {
+        let state = AppState()
+        let coordinator = AppCoordinator(state: state)
+        // Register an active subagent so description lookup works
+        state.activeSubagents["a1"] = SubagentInfo(description: "Security review", agentType: "general")
+        let data = ClaudeOutputData(type: "permission_request", tool: "Bash", toolUseId: "tu-sub-1")
+        coordinator.webSocketDidReceiveMessage(.subagentOutput(agentId: "a1", sessionId: nil, data: data))
+        // Should NOT add a chat message
+        #expect(state.messages.isEmpty)
+        // Wait for 500ms delay
+        try await Task.sleep(for: .milliseconds(700))
+        // Should be in prompt queue with agent description
+        #expect(coordinator.promptService.promptQueue.count == 1)
+        #expect(coordinator.promptService.currentPrompt?.agentDescription == "Security review")
+        #expect(coordinator.promptService.currentPrompt?.toolUseId == "tu-sub-1")
+    }
+
+    @MainActor
+    @Test("subagentOutput routes ask_user_question to prompt queue")
+    func subagentOutputRoutesQuestion() {
+        let state = AppState()
+        let coordinator = AppCoordinator(state: state)
+        let questions = [QuestionData(question: "Which approach?", options: [QuestionOption(label: "A")])]
+        let data = ClaudeOutputData(type: "ask_user_question", questions: questions)
+        coordinator.webSocketDidReceiveMessage(.subagentOutput(agentId: "a1", sessionId: nil, data: data))
+        // Questions show immediately
+        #expect(coordinator.promptService.promptQueue.count == 1)
+        if case .question(let qs) = coordinator.promptService.currentPrompt?.kind {
+            #expect(qs[0].question == "Which approach?")
+        } else {
+            Issue.record("Expected question prompt")
+        }
+    }
+
+    @MainActor
+    @Test("session switch clears prompt queue")
+    func sessionSwitchClearsPromptQueue() {
+        let state = AppState()
+        let coordinator = AppCoordinator(state: state)
+        // Add a question prompt to the queue
+        let questions = [QuestionData(question: "test")]
+        coordinator.promptService.handleClaudeOutput(ClaudeOutputData(type: "ask_user_question", questions: questions))
+        #expect(coordinator.promptService.promptQueue.count == 1)
+
+        // Switch session
+        coordinator.watchSession("new-session")
+        #expect(coordinator.promptService.promptQueue.isEmpty)
+    }
+
+    @MainActor
     @Test("two subagents full lifecycle: starting → start → tool → stop")
     func twoSubagentsFullLifecycle() {
         let state = AppState()

--- a/ClaudeRemote/Tests/ClaudeRemoteTests/Services/PromptServiceTests.swift
+++ b/ClaudeRemote/Tests/ClaudeRemoteTests/Services/PromptServiceTests.swift
@@ -28,6 +28,7 @@ struct PromptServiceTests {
         service.handleClaudeOutput(data)
         // Should NOT show immediately
         #expect(service.currentPrompt == nil)
+        #expect(service.promptQueue.isEmpty)
     }
 
     @MainActor
@@ -41,6 +42,7 @@ struct PromptServiceTests {
         // Wait for the 500ms delay to fire
         try await Task.sleep(for: .milliseconds(600))
         #expect(service.currentPrompt != nil)
+        #expect(service.promptQueue.count == 1)
         if case .permission(let tool, _, _) = service.currentPrompt?.kind {
             #expect(tool == "Bash")
         } else {
@@ -52,18 +54,19 @@ struct PromptServiceTests {
     @Test("permission_request suppressed if tool_result arrives within 500ms")
     func permissionSuppressed() async throws {
         let (service, _) = Self.makeSUT()
-        let permData = ClaudeOutputData(type: "permission_request", tool: "Bash")
+        let permData = ClaudeOutputData(type: "permission_request", tool: "Bash", toolUseId: "tu-1")
         service.handleClaudeOutput(permData)
         #expect(service.currentPrompt == nil)
 
         // tool_result arrives before 500ms
-        let resultData = ClaudeOutputData(type: "tool_result", content: "done")
+        let resultData = ClaudeOutputData(type: "tool_result", content: "done", toolUseId: "tu-1")
         service.handleClaudeOutput(resultData)
 
         // Wait past the 500ms window
         try await Task.sleep(for: .milliseconds(600))
         // Should still be nil — was suppressed
         #expect(service.currentPrompt == nil)
+        #expect(service.promptQueue.isEmpty)
     }
 
     // MARK: - Question Prompts
@@ -80,6 +83,7 @@ struct PromptServiceTests {
         service.handleClaudeOutput(data)
         // Should show immediately
         #expect(service.currentPrompt != nil)
+        #expect(service.promptQueue.count == 1)
         if case .question(let qs) = service.currentPrompt?.kind {
             #expect(qs.count == 1)
             #expect(qs[0].question == "Pick one?")
@@ -95,14 +99,15 @@ struct PromptServiceTests {
     func autoDismissOnToolResult() async throws {
         let (service, _) = Self.makeSUT()
         // Show a permission prompt
-        let data = ClaudeOutputData(type: "permission_request", tool: "Bash")
+        let data = ClaudeOutputData(type: "permission_request", tool: "Bash", toolUseId: "tu-1")
         service.handleClaudeOutput(data)
         try await Task.sleep(for: .milliseconds(600))
         #expect(service.currentPrompt != nil)
 
         // tool_result arrives
-        service.handleClaudeOutput(ClaudeOutputData(type: "tool_result"))
+        service.handleClaudeOutput(ClaudeOutputData(type: "tool_result", toolUseId: "tu-1"))
         #expect(service.currentPrompt == nil)
+        #expect(service.promptQueue.isEmpty)
     }
 
     @MainActor
@@ -115,6 +120,7 @@ struct PromptServiceTests {
 
         service.handleSessionStatus(.processing)
         #expect(service.currentPrompt == nil)
+        #expect(service.promptQueue.isEmpty)
     }
 
     @MainActor
@@ -170,6 +176,7 @@ struct PromptServiceTests {
         ]
         service.recoverFromHistory(messages, sessionStatus: .waiting)
         #expect(service.currentPrompt != nil)
+        #expect(service.promptQueue.count == 1)
         if case .permission(let tool, _, let isDestructive) = service.currentPrompt?.kind {
             #expect(tool == "Bash")
             #expect(isDestructive == true)
@@ -212,8 +219,8 @@ struct PromptServiceTests {
     func noRecoverAfterToolResult() {
         let (service, _) = Self.makeSUT()
         let messages = [
-            Message(type: .permissionRequest, tool: "Bash"),
-            Message(type: .toolResult, content: "done"),
+            Message(type: .permissionRequest, tool: "Bash", toolUseId: "tu-1"),
+            Message(type: .toolResult, content: "done", toolUseId: "tu-1"),
         ]
         service.recoverFromHistory(messages, sessionStatus: .waiting)
         #expect(service.currentPrompt == nil)
@@ -399,6 +406,196 @@ struct PromptServiceTests {
         } else {
             Issue.record("Expected permission prompt with command")
         }
+    }
+
+    // MARK: - Queue Behavior
+
+    @MainActor
+    @Test("concurrent permissions queue instead of overwriting")
+    func concurrentPermissionsQueue() async throws {
+        let (service, _) = Self.makeSUT()
+        // Send 3 permission requests rapidly
+        service.handleClaudeOutput(ClaudeOutputData(type: "permission_request", tool: "Bash", toolUseId: "tu-1"))
+        service.handleClaudeOutput(ClaudeOutputData(type: "permission_request", tool: "Write", toolUseId: "tu-2"))
+        service.handleClaudeOutput(ClaudeOutputData(type: "permission_request", tool: "Edit", toolUseId: "tu-3"))
+
+        // Wait for all 500ms delays to fire
+        try await Task.sleep(for: .milliseconds(700))
+
+        // All 3 should be in the queue
+        #expect(service.promptQueue.count == 3)
+        if case .permission(let tool, _, _) = service.promptQueue[0].kind {
+            #expect(tool == "Bash")
+        }
+        if case .permission(let tool, _, _) = service.promptQueue[1].kind {
+            #expect(tool == "Write")
+        }
+        if case .permission(let tool, _, _) = service.promptQueue[2].kind {
+            #expect(tool == "Edit")
+        }
+    }
+
+    @MainActor
+    @Test("tool_result dismisses correct queue item by toolUseId")
+    func toolResultDismissesCorrectItem() async throws {
+        let (service, _) = Self.makeSUT()
+        service.handleClaudeOutput(ClaudeOutputData(type: "permission_request", tool: "Bash", toolUseId: "tu-1"))
+        service.handleClaudeOutput(ClaudeOutputData(type: "permission_request", tool: "Write", toolUseId: "tu-2"))
+        service.handleClaudeOutput(ClaudeOutputData(type: "permission_request", tool: "Edit", toolUseId: "tu-3"))
+        try await Task.sleep(for: .milliseconds(700))
+        #expect(service.promptQueue.count == 3)
+
+        // Dismiss the middle one (Write)
+        service.handleClaudeOutput(ClaudeOutputData(type: "tool_result", toolUseId: "tu-2"))
+        #expect(service.promptQueue.count == 2)
+        // Bash and Edit should remain
+        #expect(service.promptQueue[0].toolUseId == "tu-1")
+        #expect(service.promptQueue[1].toolUseId == "tu-3")
+    }
+
+    @MainActor
+    @Test("Allow Always cascade removes matching tool permissions")
+    func allowAlwaysCascade() async throws {
+        let (service, _) = Self.makeSUT()
+        service.handleClaudeOutput(ClaudeOutputData(type: "permission_request", tool: "Bash", toolUseId: "tu-1"))
+        service.handleClaudeOutput(ClaudeOutputData(type: "permission_request", tool: "Bash", toolUseId: "tu-2"))
+        service.handleClaudeOutput(ClaudeOutputData(type: "permission_request", tool: "Write", toolUseId: "tu-3"))
+        service.handleClaudeOutput(ClaudeOutputData(type: "permission_request", tool: "Bash", toolUseId: "tu-4"))
+        try await Task.sleep(for: .milliseconds(700))
+        #expect(service.promptQueue.count == 4)
+
+        // Allow Always on head (Bash tu-1) — should cascade and remove tu-2 and tu-4
+        service.respondPermission(.allowAlways)
+        // Only Write (tu-3) should remain
+        #expect(service.promptQueue.count == 1)
+        #expect(service.promptQueue[0].toolUseId == "tu-3")
+    }
+
+    @MainActor
+    @Test("clearQueue removes all prompts")
+    func clearQueueRemovesAll() async throws {
+        let (service, _) = Self.makeSUT()
+        service.handleClaudeOutput(ClaudeOutputData(type: "permission_request", tool: "Bash", toolUseId: "tu-1"))
+        service.handleClaudeOutput(ClaudeOutputData(type: "permission_request", tool: "Write", toolUseId: "tu-2"))
+        try await Task.sleep(for: .milliseconds(700))
+        #expect(service.promptQueue.count == 2)
+
+        service.clearQueue()
+        #expect(service.promptQueue.isEmpty)
+        #expect(service.currentPrompt == nil)
+    }
+
+    @MainActor
+    @Test("session_status processing clears entire queue")
+    func processingClearsQueue() async throws {
+        let (service, _) = Self.makeSUT()
+        service.handleClaudeOutput(ClaudeOutputData(type: "permission_request", tool: "Bash", toolUseId: "tu-1"))
+        let questions = [QuestionData(question: "Pick?")]
+        service.handleClaudeOutput(ClaudeOutputData(type: "ask_user_question", questions: questions))
+        try await Task.sleep(for: .milliseconds(700))
+        #expect(service.promptQueue.count == 2)
+
+        service.handleSessionStatus(.processing)
+        #expect(service.promptQueue.isEmpty)
+    }
+
+    @MainActor
+    @Test("dismiss removes head, next item becomes currentPrompt")
+    func dismissRemovesHead() async throws {
+        let (service, _) = Self.makeSUT()
+        service.handleClaudeOutput(ClaudeOutputData(type: "permission_request", tool: "Bash", toolUseId: "tu-1"))
+        service.handleClaudeOutput(ClaudeOutputData(type: "permission_request", tool: "Write", toolUseId: "tu-2"))
+        try await Task.sleep(for: .milliseconds(700))
+        #expect(service.promptQueue.count == 2)
+
+        service.dismiss()
+        #expect(service.promptQueue.count == 1)
+        #expect(service.currentPrompt?.toolUseId == "tu-2")
+    }
+
+    @MainActor
+    @Test("agentDescription is stored on prompt item")
+    func agentDescriptionStored() async throws {
+        let (service, _) = Self.makeSUT()
+        let data = ClaudeOutputData(type: "permission_request", tool: "Bash", toolUseId: "tu-1")
+        service.handleClaudeOutput(data, agentDescription: "Security review")
+        try await Task.sleep(for: .milliseconds(700))
+        #expect(service.currentPrompt?.agentDescription == "Security review")
+    }
+
+    @MainActor
+    @Test("tool_result suppresses pending and does not affect other queue items")
+    func toolResultSuppressesPendingOnly() async throws {
+        let (service, _) = Self.makeSUT()
+        // First permission enters queue
+        service.handleClaudeOutput(ClaudeOutputData(type: "permission_request", tool: "Bash", toolUseId: "tu-1"))
+        try await Task.sleep(for: .milliseconds(700))
+        #expect(service.promptQueue.count == 1)
+
+        // Second permission starts 500ms delay
+        service.handleClaudeOutput(ClaudeOutputData(type: "permission_request", tool: "Write", toolUseId: "tu-2"))
+
+        // tool_result for the pending one arrives within 500ms
+        service.handleClaudeOutput(ClaudeOutputData(type: "tool_result", toolUseId: "tu-2"))
+
+        try await Task.sleep(for: .milliseconds(700))
+        // Only Bash should remain — Write was suppressed during delay
+        #expect(service.promptQueue.count == 1)
+        #expect(service.promptQueue[0].toolUseId == "tu-1")
+    }
+
+    @MainActor
+    @Test("history recovery finds multiple unmatched permissions")
+    func recoverMultiplePermissions() {
+        let (service, _) = Self.makeSUT()
+        let messages = [
+            Message(type: .assistant, content: "Running tools..."),
+            Message(type: .permissionRequest, tool: "Bash", toolUseId: "tu-1"),
+            Message(type: .permissionRequest, tool: "Write", toolUseId: "tu-2"),
+            Message(type: .permissionRequest, tool: "Edit", toolUseId: "tu-3"),
+        ]
+        service.recoverFromHistory(messages, sessionStatus: .waiting)
+        #expect(service.promptQueue.count == 3)
+        #expect(service.promptQueue[0].toolUseId == "tu-1")
+        #expect(service.promptQueue[1].toolUseId == "tu-2")
+        #expect(service.promptQueue[2].toolUseId == "tu-3")
+    }
+
+    @MainActor
+    @Test("history recovery skips answered permissions")
+    func recoverSkipsAnswered() {
+        let (service, _) = Self.makeSUT()
+        let messages = [
+            Message(type: .assistant, content: "Running tools..."),
+            Message(type: .permissionRequest, tool: "Bash", toolUseId: "tu-1"),
+            Message(type: .toolResult, content: "done", toolUseId: "tu-1"),
+            Message(type: .permissionRequest, tool: "Write", toolUseId: "tu-2"),
+        ]
+        service.recoverFromHistory(messages, sessionStatus: .waiting)
+        // Only Write should be recovered (Bash was answered)
+        #expect(service.promptQueue.count == 1)
+        #expect(service.promptQueue[0].toolUseId == "tu-2")
+    }
+
+    @MainActor
+    @Test("Allow Always cascade also cancels pending permissions")
+    func allowAlwaysCascadePending() async throws {
+        let (service, _) = Self.makeSUT()
+        // One in queue
+        service.handleClaudeOutput(ClaudeOutputData(type: "permission_request", tool: "Bash", toolUseId: "tu-1"))
+        try await Task.sleep(for: .milliseconds(700))
+
+        // Another Bash in pending (not yet in queue)
+        service.handleClaudeOutput(ClaudeOutputData(type: "permission_request", tool: "Bash", toolUseId: "tu-2"))
+
+        // Allow Always on head
+        service.respondPermission(.allowAlways)
+
+        // Wait for any pending to fire
+        try await Task.sleep(for: .milliseconds(700))
+
+        // Queue should be empty — tu-2 was cancelled from pending
+        #expect(service.promptQueue.isEmpty)
     }
 }
 

--- a/docs/plans/2026-02-01-fix-permission-queue-concurrent-subagents-plan.md
+++ b/docs/plans/2026-02-01-fix-permission-queue-concurrent-subagents-plan.md
@@ -1,0 +1,125 @@
+---
+title: "fix: Permission queue for concurrent subagent permissions"
+type: fix
+date: 2026-02-01
+---
+
+# fix: Permission queue for concurrent subagent permissions
+
+## Overview
+
+When Claude Code spawns many subagents in parallel (planning, brainstorming, reviewing), each can request permissions (Bash, Write, Edit). The iOS app currently handles exactly ONE permission at a time — new ones silently overwrite the previous. Subagent permissions are completely suppressed (never shown). Users see no prompts and sessions hang waiting for responses.
+
+This plan adds a stacked permission queue that shows ALL pending permissions vertically, and routes subagent permissions through the existing prompt system.
+
+## Problem Statement
+
+Two distinct bugs combine to create the issue:
+
+1. **Subagent permissions are suppressed.** `AppCoordinator.routeMessage()` has `case .subagentOutput: break` — all subagent output is dropped. The server sends subagent `permission_request` items wrapped in `subagent_output` messages, so they never reach `PromptService`.
+
+2. **Single-prompt architecture.** `PromptService.currentPrompt` is a single `PromptItem?`. `handlePermissionRequest()` calls `cancelPendingPermission()` before starting a new 500ms delay — meaning if two permissions arrive in quick succession, the first is silently lost.
+
+## Proposed Solution
+
+### A. Route subagent permissions to PromptService
+
+In `AppCoordinator.routeMessage()`, detect `permission_request` and `ask_user_question` types inside `subagentOutput` data and forward them to `promptService.handleClaudeOutput()` instead of suppressing.
+
+### B. Replace single prompt with queue
+
+In `PromptService`:
+- Replace `currentPrompt: PromptItem?` → `promptQueue: [PromptItem]`
+- Replace `pendingPermission: PromptItem?` → `pendingPermissions: [String: PromptItem]` (keyed by `toolUseId`)
+- Replace `delayTask: Task<Void, Never>?` → `delayTasks: [String: Task<Void, Never>]`
+- Queue head is the "active" prompt for voice auto-mode and response targeting
+
+### C. Update UI to show stacked queue
+
+Replace single `PromptCardView` with a bounded `ScrollView` stack showing up to 3 fully-rendered cards plus a "+N more" indicator.
+
+## Technical Considerations
+
+### Subagent injection routing
+
+Subagent permissions are brokered by the parent Claude process. The permission prompt appears in the **parent session's terminal**. Injecting "y"/"n"/"always" into the parent TTY via the existing `inject` action is correct — no server changes needed for response routing.
+
+**However**, the parent session shows these prompts sequentially. The parent waits for each subagent permission to be answered before presenting the next. This means the iOS queue is a client-side queue that mirrors what the parent terminal would show one-at-a-time. Multiple permissions may be *pending* in subagent logs, but the parent terminal only surfaces one at a time.
+
+**Implication**: The queue shows the current parent-level permission (from `claudeOutput`) AND any subagent permissions detected in `subagentOutput` that haven't been surfaced by the parent yet. The user can only respond to the one the parent is actively waiting on (queue head). Other items are informational until they become active.
+
+### 500ms delay per queue item
+
+Each incoming `permission_request` gets its own independent 500ms delay timer, keyed by `toolUseId`. This prevents auto-approved tools from flashing in the queue. The single `delayTask` pattern doesn't scale to concurrent permissions.
+
+### tool_result matching for queue dismissal
+
+When a `tool_result` arrives, match by `toolUseId` to dismiss the correct queue entry. Fall back to dismissing the oldest permission if no `toolUseId` match exists. This prevents dismissing the wrong item.
+
+### "Allow Always" cascade
+
+After sending "always" for a tool, proactively remove other queue items with the same tool name. The server-side auto-approval will handle them, but instant client-side removal avoids a flickering dismiss cascade.
+
+### Voice auto-mode
+
+Voice auto-mode processes queue head only. After responding, the next item becomes head and triggers a new TTS-then-listen cycle. No bulk voice handling.
+
+### History recovery
+
+`recoverFromHistory` must find ALL unmatched `permission_request` entries (not just the last one) by scanning for permission_request/tool_result pairs.
+
+## Acceptance Criteria
+
+- [x] Subagent `permission_request` messages route to `PromptService` (not suppressed)
+- [x] Multiple concurrent permissions queue instead of overwriting
+- [x] Each queue item has independent 500ms auto-approve delay
+- [x] `tool_result` dismisses the correct queue item by `toolUseId`
+- [x] "Allow Always" cascade removes matching tool permissions from queue
+- [x] Queue UI shows up to 3 cards with "+N more" overflow indicator
+- [x] Subagent permission cards show agent description label
+- [x] Queue head is the actionable item; others show as pending
+- [x] Session switch clears the entire queue
+- [x] Voice auto-mode processes queue head sequentially
+- [x] History recovery restores all pending permissions
+- [x] `pendingPromptMessage` dead code in AppState removed
+- [x] All existing prompt tests updated, new queue tests added
+- [x] `swift build` clean, `swift test` passes
+
+## Dependencies & Risks
+
+### Dependencies
+- No server changes required — subagent permissions already broadcast as `subagent_output`
+- No new WebSocket message types needed
+- Existing `inject` action works for subagent permission responses
+
+### Risks
+- **Subagent permission timing**: Subagent permissions in their JSONL may arrive before the parent session surfaces the prompt. Queue items from `subagentOutput` are informational until the parent actually asks. Responding to a not-yet-active permission would inject into the TTY prematurely.
+  - **Mitigation**: Only allow response on queue head. Mark non-head items as "Pending" with disabled buttons.
+- **Queue overflow**: Runaway multi-agent sessions could generate dozens of permissions.
+  - **Mitigation**: Cap rendered items at 3, show "+N more" badge, internal queue unlimited.
+- **Staleness complexity**: Per-item staleness tracking adds complexity vs. global counter.
+  - **Mitigation**: Keep global staleness for V1 — mark all items stale if 2+ messages arrive while queue is non-empty.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `PromptService.swift` | Replace single-prompt state with queue; per-item delay timers; toolUseId matching; cascade logic; history recovery |
+| `AppCoordinator.swift` | Route `subagentOutput` permission_request/ask_user_question to `PromptService`; update voice auto-mode for queue head |
+| `PromptCardView.swift` | Stack layout with ScrollView; overflow indicator; agent label on subagent cards; disabled state for non-head items |
+| `ContentView.swift` | Update `.safeAreaInset` to accommodate queue height with max bound |
+| `AppState.swift` | Remove dead `pendingPromptMessage` |
+| `WebSocketMessage.swift` | Add `toolUseId` extraction to `ClaudeOutputData` if not already present; ensure `subagentOutput` data decodes `permission_request` fields |
+| `AppCoordinatorTests.swift` | Update existing prompt tests; add queue tests (concurrent permissions, cascade, dismissal, session switch, subagent routing) |
+
+## References
+
+- Current `PromptService`: `ClaudeRemote/Sources/ClaudeRemote/Services/PromptService.swift`
+- Current `PromptCardView`: `ClaudeRemote/Sources/ClaudeRemote/Views/Components/PromptCardView.swift`
+- Subagent output suppression: `AppCoordinator.swift:349-350`
+- Server subagent broadcast: `server.js:721-752`
+- Server inject handler: `server.js:1329-1369`
+- Learned pattern — per-item delay timers: `docs/solutions/integration-issues/claude-code-remote-monitoring.md`
+- Learned pattern — fire-and-forget task risks: `docs/solutions/logic-errors/swift-structured-concurrency-pitfalls-observable-classes.md`
+- Learned pattern — generation counter for stale callbacks: `docs/solutions/concurrency-issues/trigger-word-phase5-audio-arbitration.md`
+- Learned pattern — session switch race conditions: `docs/solutions/code-quality/phase-8-review-fixes-race-security-perf.md`


### PR DESCRIPTION
## Summary
- Replaces single-prompt architecture with FIFO queue for handling multiple concurrent permission requests
- Routes subagent `permission_request` and `ask_user_question` messages to `PromptService` (previously suppressed)
- Stacked UI showing up to 3 permission cards with "+N more" overflow indicator
- Queue head is actionable; non-head items show as pending with disabled buttons

## Key Changes
- **PromptService**: `promptQueue: [PromptItem]` replaces `currentPrompt: PromptItem?`; independent 500ms delay timers per item; `toolUseId`-based dismissal; "Allow Always" cascade; sorted insertion by `arrivalOrder`
- **AppCoordinator**: `subagentOutput` handler routes `permission_request`/`ask_user_question` to prompt queue with agent description
- **PromptCardView**: Stacked card layout with pending badge, agent description labels, and overflow indicator
- **AppState**: Removed dead `pendingPromptMessage` declaration

## Test plan
- [x] `swift build` passes clean
- [x] `swift test` passes — 372 tests (21 new queue-specific tests)
- [ ] Manual test: connect to session, trigger parallel subagents, verify stacked permission cards
- [ ] Verify "Allow Always" removes matching permissions from queue
- [ ] Verify session switch clears queue cleanly
- [ ] Verify voice auto-mode processes queue head sequentially

🤖 Generated with [Claude Code](https://claude.com/claude-code)