### PR TITLE
feat(web): sync web app with iOS app protocol changes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -148,6 +148,15 @@
     </div>
 
     <div class="input-area">
+      <!-- Mode Indicator (matches iOS InputBarView utility row) -->
+      <div class="mode-bar" id="modeBar">
+        <button class="mode-btn" id="modeBtn" onclick="sendModeToggle()" title="Toggle mode">
+          <span class="mode-icon" id="modeIcon">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 16V4m0 0L3 8m4-4l4 4M17 8v12m0 0l4-4m-4 4l-4-4"/></svg>
+          </span>
+          <span class="mode-label" id="modeLabel">Default</span>
+        </button>
+      </div>
       <div class="input-row">
         <button class="action-btn more" onclick="showActionSheet()" title="More actions">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="5" r="2"/><circle cx="12" cy="12" r="2"/><circle cx="12" cy="19" r="2"/></svg>

--- a/public/js/connection.js
+++ b/public/js/connection.js
@@ -379,7 +379,9 @@ function handleMessage(msg) {
         if (currentPrompt?.type === 'permission') {
           hidePromptCard();
         }
-        break; // Don't fall through to appendMessage - tool results handled above
+        // Merge result into matching tool card (like iOS), or append standalone
+        mergeOrAppendToolResult(msg.data);
+        break;
       }
       // Dedupe user messages we just sent
       if (msg.data.type === 'user') {
@@ -394,11 +396,6 @@ function handleMessage(msg) {
       }
       // Skip subagent_starting - it's handled via subagent_start message
       if (msg.data.type === 'subagent_starting') {
-        break;
-      }
-      // Route token usage to token handler
-      if (msg.data.type === 'token_usage') {
-        handleTokenUsage(msg.data);
         break;
       }
       appendMessage(msg.data);
@@ -447,24 +444,41 @@ function handleMessage(msg) {
       handleTaskList(msg);
       break;
 
-    case 'subagent_starting':
-      // Store pending description for correlation with subagent_start
-      pendingSubagentInfo = {
-        description: msg.description,
-        type: msg.agentType,
-        timestamp: Date.now()
-      };
-      // Display as a tool message so user sees what's being launched
-      appendMessage({
-        type: 'tool',
-        tool: 'Task',
-        input: { description: msg.description, subagent_type: msg.agentType }
-      });
-      break;
+    case 'subagent_starting': {
+      // Create persistent inline activity card (matches iOS SubagentActivityCard)
+      const card = createSubagentActivityCard(msg.description, msg.agentType);
+      const outputArea = document.getElementById('outputArea');
+      outputArea.appendChild(card);
+      outputArea.scrollTop = outputArea.scrollHeight;
 
-    case 'subagent_start':
-      // Correlate with pending description if available
+      // Queue for correlation with subagent_start (FIFO, matches iOS pendingSubagentMessages)
+      const autoCompleteTimeout = setTimeout(() => {
+        // 30s auto-complete for orphaned starting cards (matches iOS)
+        updateSubagentCardStatus(card, 'completed');
+        const idx = pendingSubagentCards.findIndex(p => p.element === card);
+        if (idx !== -1) pendingSubagentCards.splice(idx, 1);
+      }, 30000);
+      pendingSubagentCards.push({ description: msg.description, element: card, timeout: autoCompleteTimeout });
+
+      // Also store for legacy correlation
+      pendingSubagentInfo = { description: msg.description, type: msg.agentType, timestamp: Date.now() };
+      break;
+    }
+
+    case 'subagent_start': {
+      // Correlate with pending card (FIFO match by description, matches iOS)
       const info = pendingSubagentInfo || {};
+      let matchedCard = null;
+      const pendingIdx = pendingSubagentCards.findIndex(p => p.description === msg.description);
+      if (pendingIdx !== -1) {
+        const pending = pendingSubagentCards[pendingIdx];
+        clearTimeout(pending.timeout);
+        matchedCard = pending.element;
+        matchedCard.dataset.agentId = msg.agentId;
+        updateSubagentCardStatus(matchedCard, 'running');
+        pendingSubagentCards.splice(pendingIdx, 1);
+      }
+
       activeSubagents.set(msg.agentId, {
         status: 'running',
         startTime: msg.timestamp,
@@ -473,11 +487,13 @@ function handleMessage(msg) {
         currentTool: null,
         inputTokens: 0,
         outputTokens: 0,
-        lastActivity: Date.now()
+        lastActivity: Date.now(),
+        cardElement: matchedCard
       });
       pendingSubagentInfo = null;
       updateSubagentIndicator();
       break;
+    }
 
     case 'subagent_output':
       handleSubagentOutput(msg.agentId, msg.data);
@@ -489,6 +505,10 @@ function handleMessage(msg) {
         agent.currentTool = msg.tool;
         agent.lastActivity = Date.now();
         updateSubagentIndicator();
+        // Update inline activity card
+        if (agent.cardElement) {
+          updateSubagentCardTool(agent.cardElement, msg.tool);
+        }
       }
       break;
 
@@ -501,10 +521,15 @@ function handleMessage(msg) {
       }
       break;
 
-    case 'subagent_stop':
+    case 'subagent_stop': {
+      const stoppedAgent = activeSubagents.get(msg.agentId);
+      if (stoppedAgent?.cardElement) {
+        updateSubagentCardStatus(stoppedAgent.cardElement, 'completed');
+      }
       activeSubagents.delete(msg.agentId);
       updateSubagentIndicator();
       break;
+    }
 
     case 'inject_result':
       if (pendingInjectResolve) {
@@ -516,6 +541,21 @@ function handleMessage(msg) {
 
     case 'error':
       showToast(msg.message, 'error');
+      break;
+
+    case 'commands':
+      // Server-provided slash commands (matches iOS: entirely server-driven)
+      if (Array.isArray(msg.data)) {
+        slashCommands = msg.data.map(c => ({
+          cmd: '/' + c.name,
+          desc: c.description || ''
+        }));
+      }
+      break;
+
+    case 'mode_change':
+      currentMode = msg.mode || 'default';
+      updateModeIndicator();
       break;
 
     case 'pong':

--- a/public/js/sessions.js
+++ b/public/js/sessions.js
@@ -79,7 +79,12 @@ function switchSession() {
   resetSessionTokens();
   clearTasks();
   activeSubagents.clear();
+  // Clear pending subagent card timeouts
+  pendingSubagentCards.forEach(p => clearTimeout(p.timeout));
+  pendingSubagentCards.length = 0;
   updateSubagentIndicator();
+  currentMode = 'default';
+  updateModeIndicator();
   document.getElementById('statusBar')?.classList.add('hidden');
 
   wsSend({ action: 'watch_session', sessionId: sessionId });
@@ -355,6 +360,57 @@ function refreshSessions() {
 }
 
 // ============================================
+// Tool Result Merging (matches iOS mergeOrAppendToolResult)
+// ============================================
+function mergeOrAppendToolResult(data) {
+  const toolUseId = data.toolUseId;
+  if (toolUseId) {
+    // Find the last tool card with matching toolUseId
+    const outputArea = document.getElementById('outputArea');
+    const allTools = outputArea.querySelectorAll(`.message.tool[data-tool-use-id="${CSS.escape(toolUseId)}"]`);
+    const matchingCard = allTools.length > 0 ? allTools[allTools.length - 1] : null;
+
+    if (matchingCard) {
+      // Merge: append result inline into the existing tool card
+      const result = typeof data.content === 'string' ? data.content : JSON.stringify(data.content, null, 2);
+      const isError = !!data.resultIsError;
+      const lang = pending.lastToolLanguage || 'plaintext';
+
+      // Add result section to the tool card
+      const resultDiv = document.createElement('div');
+      resultDiv.className = `tool-result-inline${isError ? ' error' : ''}`;
+      const lines = result.split('\n');
+      const preview = lines[0].substring(0, 50);
+      const needsEllipsis = lines[0].length > 50 || lines.length > 1;
+      resultDiv.innerHTML = `
+        <div class="tool-result-separator"></div>
+        <div class="tool-result-header">
+          <span class="tool-result-icon">${isError ? '✕' : '✓'}</span>
+          <span class="tool-result-preview">${escapeHtml(preview)}${needsEllipsis ? '...' : ''} (${lines.length} lines)</span>
+        </div>
+        <div class="tool-result-details"><pre>${escapeHtml(result)}</pre></div>
+      `;
+      matchingCard.appendChild(resultDiv);
+
+      // Update the chevron summary to show completion status
+      const summary = matchingCard.querySelector('.tool-summary');
+      if (summary) {
+        const statusIcon = document.createElement('span');
+        statusIcon.className = `tool-status-icon${isError ? ' error' : ''}`;
+        statusIcon.textContent = isError ? '✕' : '✓';
+        summary.appendChild(statusIcon);
+      }
+
+      outputArea.scrollTop = outputArea.scrollHeight;
+      return;
+    }
+  }
+
+  // Fallback: append as standalone tool_result message
+  appendMessage(data);
+}
+
+// ============================================
 // Output Rendering
 // ============================================
 function renderHistory(history) {
@@ -432,6 +488,11 @@ function appendMessage(data, scroll = true, skipPromptDetection = false, subagen
     showToast(`CLASS: ${msg.className}`, 'success');
   }
 
+  // Store toolUseId for tool card merging (matches iOS)
+  if (data.toolUseId && (data.type === 'tool' || data.type === 'permission_request')) {
+    msg.dataset.toolUseId = data.toolUseId;
+  }
+
   if (data.type === 'tool') {
     const toolInput = formatToolInput(data.input);
     // Guard against null/undefined input
@@ -469,7 +530,7 @@ function appendMessage(data, scroll = true, skipPromptDetection = false, subagen
       `;
     }
   } else if (data.type === 'tool_result') {
-    const result = typeof data.result === 'string' ? data.result : JSON.stringify(data.result, null, 2);
+    const result = typeof data.content === 'string' ? data.content : JSON.stringify(data.content, null, 2);
     // Split once, reuse for preview and line count
     const lines = result.split('\n');
     const preview = lines[0].substring(0, 50);

--- a/public/js/state.js
+++ b/public/js/state.js
@@ -114,8 +114,16 @@ const pending = {
   lastToolLanguage: 'plaintext' // Last tool language for syntax highlighting
 };
 
+// Session mode (matches iOS: 'default', 'plan', 'acceptEdits')
+let currentMode = 'default';
+
+// Slash commands from server (replaces hardcoded COMMANDS array)
+let slashCommands = [];
+
 // Active subagents: agentId -> { status, startTime, description, lastActivity }
 const activeSubagents = new Map();
+// Pending subagent descriptions for correlation with subagent_start (FIFO queue, matches iOS)
+const pendingSubagentCards = []; // { description, element, timeout }
 // Pending subagent permissions: agentId -> { timeout, card }
 const pendingSubagentPermissions = new Map();
 

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -142,37 +142,19 @@ function autoResize(el) {
 }
 
 // ============================================
-// Command Autocomplete
+// Command Autocomplete (server-driven, matches iOS)
 // ============================================
-const COMMANDS = [
-  { cmd: '/workflows:plan', desc: 'Create implementation plan' },
-  { cmd: '/workflows:work', desc: 'Execute a plan' },
-  { cmd: '/workflows:review', desc: 'Code review with agents' },
-  { cmd: '/workflows:brainstorm', desc: 'Explore approaches' },
-  { cmd: '/workflows:compound', desc: 'Document a solved problem' },
-  { cmd: '/commit', desc: 'Commit changes' },
-  { cmd: '/commit-and-pr', desc: 'Commit and create PR' },
-  { cmd: '/clear', desc: 'Clear conversation' },
-  { cmd: '/compact', desc: 'Compact context' },
-  { cmd: '/status', desc: 'Show status' },
-  { cmd: '/help', desc: 'Show help' },
-  { cmd: '/plan', desc: 'Enter plan mode' },
-  { cmd: '/explore', desc: 'Explore codebase' },
-  { cmd: '/security-review', desc: 'Security checklist' },
-  { cmd: '/generate-tests', desc: 'Generate tests' },
-  { cmd: '/fresh-eyes-review', desc: 'Unbiased code review' },
-  { cmd: '/refactor', desc: 'Guided refactoring' },
-];
-
 let autocompleteIndex = -1;
 
 function handleInput(el) {
   autoResize(el);
   const value = el.value;
 
-  if (value.startsWith('/')) {
+  if (value.startsWith('/') && slashCommands.length > 0) {
     const query = value.toLowerCase();
-    const matches = COMMANDS.filter(c => c.cmd.toLowerCase().includes(query));
+    const matches = slashCommands
+      .filter(c => c.cmd.toLowerCase().includes(query))
+      .slice(0, 6); // Max 6 suggestions (matches iOS)
     if (matches.length > 0) {
       showAutocomplete(matches);
     } else {
@@ -546,6 +528,37 @@ function updateSettings() {
 }
 
 // ============================================
+// Mode Indicator (matches iOS InputBarView)
+// ============================================
+function updateModeIndicator() {
+  const btn = document.getElementById('modeBtn');
+  const icon = document.getElementById('modeIcon');
+  const label = document.getElementById('modeLabel');
+  if (!btn) return;
+
+  // Remove old mode classes
+  btn.classList.remove('mode-default', 'mode-plan', 'mode-acceptEdits');
+
+  switch (currentMode) {
+    case 'plan':
+      btn.classList.add('mode-plan');
+      label.textContent = 'Plan';
+      icon.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6"/><path d="M16 13H8"/><path d="M16 17H8"/><path d="M10 9H8"/></svg>';
+      break;
+    case 'acceptEdits':
+      btn.classList.add('mode-acceptEdits');
+      label.textContent = 'Accept Edits';
+      icon.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>';
+      break;
+    default:
+      btn.classList.add('mode-default');
+      label.textContent = 'Default';
+      icon.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 16V4m0 0L3 8m4-4l4 4M17 8v12m0 0l4-4m-4 4l-4-4"/></svg>';
+      break;
+  }
+}
+
+// ============================================
 // Status Bar and Token Tracking
 // ============================================
 let sessionTokens = { input: 0, output: 0 };
@@ -567,7 +580,7 @@ function handleStatusUpdate(data) {
   const statusVerb = document.getElementById('statusVerb');
 
   statusBar.classList.remove('hidden');
-  statusVerb.textContent = data.text || 'Working...';
+  statusVerb.textContent = data.content || 'Working...';
   updateActionButtons();
 
   // Auto-hide after 5 seconds of no updates
@@ -678,6 +691,49 @@ function clearTasks() {
 // ============================================
 // Subagent Handling
 // ============================================
+
+// Persistent inline activity cards (matches iOS SubagentActivityCard lifecycle)
+function createSubagentActivityCard(description, agentType) {
+  const card = document.createElement('div');
+  card.className = 'subagent-activity-card starting';
+  card.innerHTML = `
+    <div class="subagent-card-icon">
+      <span class="subagent-card-spinner"></span>
+    </div>
+    <div class="subagent-card-content">
+      <span class="subagent-card-status">Starting</span>: <span class="subagent-card-desc">${escapeHtml(description || 'Subagent')}</span>
+      <span class="subagent-card-tool"></span>
+    </div>
+  `;
+  return card;
+}
+
+function updateSubagentCardStatus(card, status) {
+  if (!card) return;
+  card.classList.remove('starting', 'running', 'completed');
+  card.classList.add(status);
+
+  const iconEl = card.querySelector('.subagent-card-icon');
+  const statusEl = card.querySelector('.subagent-card-status');
+  const toolEl = card.querySelector('.subagent-card-tool');
+
+  if (status === 'running') {
+    statusEl.textContent = 'Running';
+  } else if (status === 'completed') {
+    statusEl.textContent = 'Completed';
+    iconEl.innerHTML = '<span class="subagent-card-check">✓</span>';
+    if (toolEl) toolEl.textContent = '';
+  }
+}
+
+function updateSubagentCardTool(card, tool) {
+  if (!card) return;
+  const toolEl = card.querySelector('.subagent-card-tool');
+  if (toolEl) {
+    toolEl.textContent = tool ? ` — ${tool}` : '';
+  }
+}
+
 function updateSubagentIndicator() {
   const indicator = document.getElementById('subagentIndicator');
   const countEl = indicator.querySelector('.subagent-count');

--- a/public/styles.css
+++ b/public/styles.css
@@ -168,6 +168,64 @@ body {
   gap: 4px;
 }
 
+/* Subagent Activity Cards (persistent inline, matches iOS SubagentActivityCard) */
+.subagent-activity-card {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 500;
+  margin: 4px 0;
+  transition: background 0.2s, color 0.2s;
+}
+.subagent-activity-card.starting,
+.subagent-activity-card.running {
+  background: rgba(255, 159, 10, 0.10);
+  color: var(--orange);
+}
+.subagent-activity-card.completed {
+  background: rgba(48, 209, 88, 0.08);
+  color: var(--success);
+}
+.subagent-card-icon {
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.subagent-card-spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(255, 159, 10, 0.3);
+  border-top-color: var(--orange);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+.subagent-card-check {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--success);
+}
+.subagent-card-content {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.subagent-card-status {
+  font-weight: 600;
+}
+.subagent-card-tool {
+  color: var(--text-secondary);
+  font-weight: 400;
+}
+
 /* Subagent message styling */
 .message.subagent-message {
   opacity: 0.8;
@@ -389,6 +447,54 @@ body {
   font-size: 11px;
 }
 
+/* Tool result merge (inline in tool card - matches iOS) */
+.tool-result-inline {
+  margin-top: 6px;
+}
+.tool-result-separator {
+  height: 0.5px;
+  background: var(--separator);
+  margin: 6px 0;
+}
+.tool-result-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.tool-result-icon {
+  font-size: 12px;
+  color: var(--success);
+  font-weight: 600;
+}
+.tool-result-inline.error .tool-result-icon {
+  color: var(--error);
+}
+.tool-result-details {
+  display: none;
+  margin-top: 6px;
+  padding: 8px;
+  background: var(--bg-grouped);
+  border-radius: 6px;
+  font-size: 11px;
+  max-height: 150px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+}
+.message.tool.expanded .tool-result-details {
+  display: block;
+}
+.tool-status-icon {
+  font-size: 12px;
+  color: var(--success);
+  font-weight: 600;
+  margin-left: auto;
+}
+.tool-status-icon.error {
+  color: var(--error);
+}
+
 /* Collapsible tool messages - iOS Style */
 .message.tool, .message.tool_result {
   cursor: pointer;
@@ -519,6 +625,47 @@ body {
 @keyframes bounce {
   0%, 80%, 100% { transform: scale(0); opacity: 0.4; }
   40% { transform: scale(1); opacity: 1; }
+}
+
+/* Mode Bar (matches iOS InputBarView utility row) */
+.mode-bar {
+  display: flex;
+  align-items: center;
+  padding: 0 12px 6px;
+}
+.mode-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--bg-input);
+  border: none;
+  border-radius: 14px;
+  padding: 5px 12px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s, transform 0.1s;
+}
+.mode-btn:active {
+  transform: scale(0.95);
+}
+.mode-btn .mode-icon {
+  display: flex;
+  align-items: center;
+}
+.mode-btn.mode-default {
+  color: var(--text-secondary);
+}
+.mode-btn.mode-plan {
+  color: var(--orange);
+  background: rgba(255, 159, 10, 0.12);
+}
+.mode-btn.mode-acceptEdits {
+  color: var(--success);
+  background: rgba(48, 209, 88, 0.12);
+}
+.mode-btn .mode-icon svg {
+  stroke: currentColor;
 }
 
 /* Input Area - iOS Style */


### PR DESCRIPTION
The web client was frozen at the modular refactor (72cd98f) while the
server evolved to support the iOS native app. This brings the web app
back in sync:

- Fix breaking field names: data.text→data.content (status_update),
  data.result→data.content (tool_result)
- Add toolUseId-based tool card merging (tool_result rendered inline
  in matching tool card, with fallback to standalone)
- Replace hardcoded COMMANDS array with server-provided slash commands
  (entirely server-driven, max 6 suggestions, matches iOS)
- Add clickable mode indicator (Default/Plan/Accept Edits) with
  icon, label, and color tint matching iOS InputBarView
- Add persistent inline subagent activity cards with full lifecycle:
  starting→running→completed, 30s orphan auto-complete timeout
- Remove dead token_usage handler in claude_output case
- Reset mode and pending subagent cards on session switch

https://claude.ai/code/session_01WCZWVDSUWotz91fiPVDHWE